### PR TITLE
EDN.register should default to the identity function when no handler is given

### DIFF
--- a/lib/edn.rb
+++ b/lib/edn.rb
@@ -35,7 +35,9 @@ module EDN
       func = block
     end
 
-    raise "EDN.register requires a block or callable." if func.nil?
+    if func.nil?
+      func = lambda { |x| x }
+    end
 
     if func.is_a?(Class)
       @tags[tag] = lambda { |*args| func.new(*args) }

--- a/spec/edn_spec.rb
+++ b/spec/edn_spec.rb
@@ -68,6 +68,13 @@ describe EDN do
     end
   end
 
+  context "#register" do
+    it "uses the identity function when no handler is given" do
+      EDN.register "some/tag"
+      EDN.read("#some/tag {}").class.should == Hash
+    end
+  end
+
   context "writing" do
     it "writes any valid element" do
       elements = rant(RantlyHelpers::ELEMENT)


### PR DESCRIPTION
This is a common pattern when tagging EDN primitives for descriptive purposes; no special constructor is needed.
