### PR TITLE
Fix error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,12 @@ EDN.tagout("wolf/pack", {:alpha=>"Greybeard", :betas=>["Frostpaw", "Blackwind", 
 
 class Range
   def to_edn
-    EDN.tagout("my/range", self.to_a)
+    EDN.tagout("ruby/range", [self.begin, self.end, self.exclude_end?])
   end
 end
 
 (0..9).to_edn
- => "#my/range [0 1 2 3 4 5 6 7 8 9]"
+=> "#ruby/range [0 9 false]"
 ```
 
 


### PR DESCRIPTION
There was an error involving EDN.tagout on a range in the README, as mentioned by issue #13.
