### PR TITLE
Poor man stream parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ end
 r.count #=> 2
 ```
 
+### Stream reading
+
+If you want to parse **edn** in chunks (for example, when reading the data from stream), you can use `EDN::StreamReader`.
+
+```ruby
+r = EDN::StreamReader.new(lambda {|form| p form})
+
+r << "[1 2" # handler isn't called because the form is not complete
+r << "] {:a 1 :b 2}"
+
+#=> [1, 2, 3]
+#=> {:a => 1, :b => 2}
+
+```
+
 ### Value Translations
 
 **edn** has some different terminology, and some types that do not map cleanly to Ruby.

--- a/lib/edn.rb
+++ b/lib/edn.rb
@@ -5,6 +5,7 @@ require 'edn/types'
 require 'edn/parser'
 require 'edn/transform'
 require 'edn/reader'
+require 'edn/stream_reader'
 
 module EDN
   class ParseFailed < StandardError

--- a/lib/edn/stream_reader.rb
+++ b/lib/edn/stream_reader.rb
@@ -1,0 +1,42 @@
+module EDN
+  class StreamReader
+
+    def initialize(handler)
+      @handler   = handler
+      @parser    = Parser.new
+      @transform = Transform.new
+    end
+
+    def <<(s)
+      @buffer ||= ''
+      @buffer << s
+
+      begin
+        consume
+      rescue Parslet::ParseFailed => ignored
+        # ignore the parsing exceptions
+        # the form is incomplete, we'll parse when next chunk arrives
+      end
+      
+      self
+    end
+
+    def close
+      consume
+    end
+
+    def reset
+      @buffer = nil
+    end
+
+    private
+
+    def consume
+      while @buffer
+        element, rest = @parser.parse_prefix(@buffer)
+        @buffer       = rest
+        @handler.call(@transform.apply(element))
+      end
+    end
+  end
+end

--- a/spec/edn/stream_reader_spec.rb
+++ b/spec/edn/stream_reader_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe EDN::StreamReader do
+  let(:forms)  { [] }
+  let(:reader) { EDN::StreamReader.new(lambda {|form| forms << form}) }
+
+  before do
+    forms.clear
+    reader.reset
+  end
+
+  it "should read full form" do
+    reader << "1"
+    forms.count.should == 1
+    forms.first.should == 1
+  end
+
+  it "should read form in chunks" do
+    reader << "[1 2"
+    forms.count.should == 0
+    reader << "]"
+    forms.count.should == 1
+    forms.first.should == [1, 2]
+  end
+
+  it "should read multiple forms in chunks" do
+    reader << "[1 2"
+    forms.count.should == 0
+    reader << "] {:a 1, :b "
+    forms.count.should == 1
+    reader << "2}"
+    forms.count.should == 2
+  end
+
+  it "should read multiple forms in the same chunk" do
+    reader << "[1 2] [3 4]"
+    forms.count.should == 2
+  end
+
+  it "should support chaining" do
+    reader << "1" << "2"
+    forms.count.should == 2
+  end
+
+end


### PR DESCRIPTION
I have two processes that communicate to each other via stdin and stdout/stderr. I wanted to use edn, but couldn't use regular `EDN::Reader` because when i'm reading from stdin, i read in chunks. `EDN::StreamReader` adds this ability.

It's not the best implementation in terms of speed (it attempts to parse the buffer every time there is a new chunk), but it does the job and is very simple.
