### PR TITLE
cannot parse symbol starting with true or false

### DIFF
--- a/lib/edn/parser.rb
+++ b/lib/edn/parser.rb
@@ -54,7 +54,7 @@ module EDN
       set |
       map |
       boolean |
-      str('nil').as(:nil) |
+      _nil |
       keyword |
       string |
       character |
@@ -131,7 +131,11 @@ module EDN
     }
 
     rule(:boolean) {
-      str('true').as(:true) | str('false').as(:false)
+      (str('true').as(:true) | str('false').as(:false)) >> valid_chars.absent?
+    }
+
+    rule(:_nil) {
+      str('nil').as(:nil) >> valid_chars.absent?
     }
 
     # Parts

--- a/spec/edn_spec.rb
+++ b/spec/edn_spec.rb
@@ -71,6 +71,20 @@ describe EDN do
         end
       end
     end
+
+    context "allows symbols starting with a reserved word" do
+      it "reads true-foo" do
+        EDN.read('true-foo').should == EDN::Type::Symbol.new('true-foo')
+      end
+
+      it "reads falsey" do
+        EDN.read('falsey').should == EDN::Type::Symbol.new('falsey')
+      end
+
+      it "reads nillable" do
+       EDN.read('nillable').should == EDN::Type::Symbol.new('nillable')
+      end
+    end
   end
 
   context "#register" do


### PR DESCRIPTION
`true-cat` or `falsetrue` etc. will not parse as the reader matches the boolean first. 
