### PR TITLE
Empty string to EDN and then back again does not give an empty string

### DIFF
--- a/lib/edn/string_transformer.rb
+++ b/lib/edn/string_transformer.rb
@@ -21,8 +21,8 @@ module EDN
     end
 
     def self.parse_string(string)
+      return '' if string.size == 0
       string = string.to_s
-      return '' if string.empty?
       string = string.gsub(%r((?:\\[\\bfnrt"/]|(?:\\u(?:[A-Fa-f\d]{4}))+|\\[\x20-\xff]))n) do |c|
         #" Clear messed up syntax highlighting with Emacs.
         if u = UNESCAPE_MAP[$&[1]]

--- a/lib/edn/transform.rb
+++ b/lib/edn/transform.rb
@@ -20,7 +20,7 @@ module EDN
       end
     }
 
-    rule(:string => simple(:x)) { EDN::StringTransformer.parse_string(x) }
+    rule(:string => subtree(:x)) { EDN::StringTransformer.parse_string(x) }
     rule(:keyword => simple(:x)) { x.to_sym }
     rule(:symbol => simple(:x)) { EDN::Type::Symbol.new(x) }
     rule(:character => simple(:x)) {

--- a/spec/edn/parser_spec.rb
+++ b/spec/edn/parser_spec.rb
@@ -124,6 +124,10 @@ describe EDN::Parser do
   end
 
   context "string" do
+    it "should consume an empty string" do
+      parser.string.should parse('""')
+    end
+
     it "should consume any string" do
       rant(RantlyHelpers::STRING).each do |string|
         parser.string.should parse(string)

--- a/spec/edn/transform_spec.rb
+++ b/spec/edn/transform_spec.rb
@@ -25,6 +25,10 @@ describe EDN::Transform do
     it "should not evaluate interpolated Ruby code" do
       subject.apply(:string => 'hello\n#{world}').should == "hello\n\#{world}"
     end
+
+    it "should emit an empty string when input is empty array" do
+      subject.apply(:string => []).should == ""
+    end
   end
 
   context "keyword" do

--- a/spec/edn_spec.rb
+++ b/spec/edn_spec.rb
@@ -8,7 +8,6 @@ describe EDN do
       EDN.read("1").should == 1
       EDN.read("3.14").should == 3.14
       EDN.read("3.14M").should == BigDecimal("3.14")
-      EDN.read('"hello\nworld"').should == "hello\nworld"
       EDN.read(':hello').should == :hello
       EDN.read(':hello/world').should == :"hello/world"
       EDN.read('hello').should == EDN::Type::Symbol.new('hello')
@@ -26,6 +25,11 @@ describe EDN do
 
     it "reads #inst tagged elements" do
       EDN.read('#inst "2012-09-10T16:16:03-04:00"').should == DateTime.new(2012, 9, 10, 16, 16, 3, '-04:00')
+    end
+
+    it "reads strings" do
+      EDN.read('""').should == ""
+      EDN.read('"hello\nworld"').should == "hello\nworld"
     end
 
     it "reads vectors" do


### PR DESCRIPTION
Using 1.0.2 if I encode an empty string to EDN and back again I don't get an empty string but instead a hash

in ruby console

> > a = "".to_edn
> > => "\"\""
> > EDN.read a
> > => {:string=>[]}

Is this correct or a bug ??
