### PR TITLE
Properly handle empty strings

### DIFF
--- a/lib/edn/transform.rb
+++ b/lib/edn/transform.rb
@@ -20,6 +20,7 @@ module EDN
       end
     }
 
+    rule(:string => []) { "" }
     rule(:string => simple(:x)) { EDN::StringTransformer.parse_string(x) }
     rule(:keyword => simple(:x)) { x.to_sym }
     rule(:symbol => simple(:x)) { EDN::Type::Symbol.new(x) }

--- a/spec/edn/transform_spec.rb
+++ b/spec/edn/transform_spec.rb
@@ -25,6 +25,10 @@ describe EDN::Transform do
     it "should not evaluate interpolated Ruby code" do
       subject.apply(:string => 'hello\n#{world}').should == "hello\n\#{world}"
     end
+
+    it "should emit empty strings as strings" do
+      subject.apply(:string => []).should == ""
+    end
   end
 
   context "keyword" do


### PR DESCRIPTION
It seems that the parser emits `{:string => []}` as the result of parsing `""`. The transformer should convert this empty string hash to `""` in Ruby.
