### PR TITLE
Remove superfluous inclusion

### DIFF
--- a/lib/edn/type/list.rb
+++ b/lib/edn/type/list.rb
@@ -1,7 +1,5 @@
 module EDN
   module Type
-    include EDN::CoreExt::AllowsMetadata
-
     class List < ::Array
       def self.new(*values)
         self.[](*values)


### PR DESCRIPTION
The `EDN::Type` module does not need this.

Also, `EDN::Type::List` already includes `EDN::CoreExt::AllowsMetadata`
through its parent class, Array.
