### PR TITLE
Fuzzy check floats

### DIFF
--- a/spec/edn_spec.rb
+++ b/spec/edn_spec.rb
@@ -134,7 +134,7 @@ describe EDN do
       elements.each do |element|
         ruby_element = EDN.read(element)
 
-        if ruby_element.respond_to?(:round)
+        if ruby_element.kind_of?(Numeric)
           ruby_element.should be_within(0.1).of(EDN.read(ruby_element.to_edn))
         else
           ruby_element.should == EDN.read(ruby_element.to_edn)


### PR DESCRIPTION
This is to fix the intermittent travis failures on the JVM for #28. I suspect 
that they are related to exact comparison of floats. This change allows floats
to be close enough.
