### PR TITLE
Remove require pry

### DIFF
--- a/lib/edn/parser.rb
+++ b/lib/edn/parser.rb
@@ -1,6 +1,5 @@
 require 'stringio'
 require 'set'
-require 'pry'
 
 
 module EDN


### PR DESCRIPTION
There was an accidental inclusion of `require 'pry'` added to parser.rb

```
➜  ~  cat Gemfile
# A sample Gemfile
source "https://rubygems.org"

gem "edn", "1.0.5"
➜  ~  cat Gemfile.lock
GEM
  remote: https://rubygems.org/
  specs:
    edn (1.0.5)

PLATFORMS
  ruby

DEPENDENCIES
  edn (= 1.0.5)
➜  ~  irb
irb(main):001:0>
➜  ~  bundle exec irb
irb(main):001:0> require 'edn'
LoadError: cannot load such file -- pry
    from /Users/krukow/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/edn-1.0.5/lib/edn/parser.rb:3:in `require'
    from /Users/krukow/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/edn-1.0.5/lib/edn/parser.rb:3:in `<top (required)>'
    from /Users/krukow/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/edn-1.0.5/lib/edn.rb:7:in `require'
    from /Users/krukow/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/edn-1.0.5/lib/edn.rb:7:in `<top (required)>'
    from (irb):1:in `require'
    from (irb):1
    from /Users/krukow/.rbenv/versions/2.0.0-p247/bin/irb:12:in `<main>'
irb(main):002:0>
```

This pull request removes the require.
