### PR TITLE
Add encoding to spec file for Ruby 1.9 Travis CI builds

### DIFF
--- a/spec/edn_spec.rb
+++ b/spec/edn_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'spec_helper'
 require 'stringio'
 


### PR DESCRIPTION
I noticed the Travis CI builds were failing for all the Ruby 1.9 builds.  Just added the encoding comment to the spec to get everything to pass for 1.9.
