### PR TITLE
feature: Adds EDN::Type::Keyword

### DIFF
--- a/lib/edn.rb
+++ b/lib/edn.rb
@@ -49,6 +49,10 @@ module EDN
     ["##{tag}", element.to_edn].join(" ")
   end
 
+  def self.keyword(text)
+    EDN::Type::Keyword.new(text)
+  end
+
   def self.symbol(text)
     EDN::Type::Symbol.new(text)
   end

--- a/lib/edn/type/keyword.rb
+++ b/lib/edn/type/keyword.rb
@@ -1,0 +1,25 @@
+module EDN
+  module Type
+    class Keyword
+      attr_reader :keyword
+
+      def initialize(keyword)
+        @keyword = keyword
+      end
+
+      def ==(other)
+        return false unless other.is_a?(Keyword)
+        keyword == other.keyword
+      end
+      alias :eql? :==
+
+      def to_s
+        keyword.to_s
+      end
+
+      def to_edn
+        ":#{to_s}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
There are some valid keywords in EDN which can't be expressed as Ruby
keywords, for example `:foo-bar`.  This creates a new class,
`EDN::Types::Keyword`, which allows the consumer to convert an
arbitrary Ruby string to an EDN keyword.
