### PR TITLE
Make reader enumerable

### DIFF
--- a/lib/edn/reader.rb
+++ b/lib/edn/reader.rb
@@ -1,5 +1,6 @@
 module EDN
   class Reader
+    include Enumerable
 
     def initialize(source)
       @parser = EDN.new_parser(source)


### PR DESCRIPTION
Allows for all [enumerable methods](https://ruby-doc.org/core-2.5.1/Enumerable.html) such as `to_a`, `first`, etc. to be called on the reader directly.

e.g.
```ruby
2.4.4 :021 > EDN::Reader.new('[1 2 3] {:a 1 :b 2}').to_a
 => [[1, 2, 3], {:a=>1, :b=>2}]
```