### PR TITLE
General fixes

### DIFF
--- a/.circleci/config.yaml
+++ b/.circleci/config.yaml
@@ -1,0 +1,146 @@
+version: 2.1
+
+commands:
+  login_to_artifactory:
+    description: Login to Artifactory
+    steps:
+      - run:
+          name: Login to Artifactory
+          command: |
+            mkdir -p ~/.gem
+            curl -u "$ARTIFACTORY_USER":"$ARTIFACTORY_PASSWORD" https://fundingcircle.jfrog.io/fundingcircle/api/gems/rubygems/api/v1/api_key.yaml > ~/.gem/credentials
+            chmod 600 ~/.gem/credentials
+  push_gem_to_artifactory:
+    description: Push gem to Artifactory
+    parameters:
+      repository:
+        type: string
+        default: "does not exist"
+    steps:
+      - run:
+          name: Push gem to Artifactory
+          command: |
+            package=$(ls -t1 ${CIRCLE_PROJECT_REPONAME}*.gem | head -1)
+            gem push $package --host https://fundingcircle.jfrog.io/fundingcircle/api/gems/<< parameters.repository >>
+
+executors:
+  ruby:
+    docker:
+      - image: circleci/ruby:<< parameters.tag >>
+    parameters:
+      tag:
+        type: string
+        default: latest
+    working_directory: ~/edn_ruby
+
+jobs:
+  build:
+    parameters:
+      tag:
+        type: string
+        default: latest
+    executor:
+      name: ruby
+      tag: << parameters.tag >>
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - edn_ruby-<< parameters.tag >>-{{ checksum "edn.gemspec" }}
+      - run:
+          name: Install gems
+          command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
+      - save_cache:
+          key: edn_ruby-<< parameters.tag >>-{{ checksum "edn.gemspec" }}
+          paths:
+            - vendor/bundle
+      - run:
+          name: Run tests
+          command: bundle exec rspec --color --format progress spec
+  publish-feature-branch-gem:
+    executor:
+      name: ruby
+      tag: latest
+    steps:
+      - checkout
+      - run:
+          name: Install gem-versioner
+          command: gem install gem-versioner
+      - run:
+          name: Build gem
+          command: PRE_RELEASE=$CIRCLE_BRANCH gem build "$CIRCLE_PROJECT_REPONAME".gemspec
+      - login_to_artifactory
+      - push_gem_to_artifactory:
+          repository: "rubygems-pre-releases"
+  publish-tagged-gem:
+    executor:
+      name: ruby
+      tag: latest
+    steps:
+      - checkout
+      - run:
+          name: Build gem
+          command: gem build "$CIRCLE_PROJECT_REPONAME".gemspec
+      - login_to_artifactory
+      - push_gem_to_artifactory:
+          repository: "rubygems-local"
+
+workflows:
+  test-and-publish:
+    jobs:
+      - build:
+          name: ruby23
+          tag: "2.3"
+          filters:
+            tags:
+              only: /.*/
+      - build:
+          name: ruby24
+          tag: "2.4"
+          filters:
+            tags:
+              only: /.*/
+      - build:
+          name: ruby25
+          tag: "2.5"
+          filters:
+            tags:
+              only: /.*/
+      - build:
+          name: ruby26
+          tag: "2.6"
+          filters:
+            tags:
+              only: /.*/
+      - build:
+          name: rubylatest
+          tag: "latest"
+          filters:
+            tags:
+              only: /.*/
+      - publish-feature-branch-gem:
+          context: org-global
+          filters:
+            branches:
+              ignore: master
+            tags:
+              ignore: /.*/
+          requires:
+            - ruby23
+            - ruby24
+            - ruby25
+            - ruby26
+            - rubylatest
+      - publish-tagged-gem:
+          context: org-global
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*$/
+          requires:
+            - ruby23
+            - ruby24
+            - ruby25
+            - ruby26
+            - rubylatest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: ruby
-rvm:
-  - "1.9.2"
-  - "1.9.3"
-  - "2.0.0"
-  - jruby-19mode # JRuby in 1.9 mode
-#   - "1.8.7"
-#   - jruby-18mode # JRuby in 1.8 mode
-script: bundle exec rspec spec

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,14 @@
 #!/usr/bin/env rake
-require "bundler/gem_tasks"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec
 
 task :irb do
-  sh "irb -I lib -r edn"
-  sh "reset"
+  sh 'irb -I lib -r edn'
+  sh 'reset'
 end

--- a/edn.gemspec
+++ b/edn.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'pry', '~> 0.9.10'
   gem.add_development_dependency 'rake', '~> 10.3'
   gem.add_development_dependency 'rantly', '~> 0.3.1'
-  gem.add_development_dependency 'rspec', '~> 2.11.0'
+  gem.add_development_dependency 'rspec', '~> 3.8'
 end

--- a/edn.gemspec
+++ b/edn.gemspec
@@ -1,23 +1,24 @@
-# -*- encoding: utf-8 -*-
-require File.expand_path('../lib/edn/version', __FILE__)
+# frozen_string_literal: true
+
+require File.expand_path('lib/edn/version', __dir__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Clinton N. Dreisbach & Russ Olsen"]
-  gem.email         = ["russ@russolsen.com"]
-  gem.description   = %q{'edn implements a reader for Extensible Data Notation by Rich Hickey.'}
+  gem.authors       = ['Clinton N. Dreisbach & Russ Olsen']
+  gem.email         = ['russ@russolsen.com']
+  gem.description   = "'edn implements a reader for Extensible Data Notation by Rich Hickey.'"
   gem.summary       = gem.description
-  gem.homepage      = "https://github.com/relevance/edn-ruby"
-  gem.license       = "MIT"
+  gem.homepage      = 'https://github.com/relevance/edn-ruby'
+  gem.license       = 'MIT'
 
-  gem.files         = `git ls-files`.split($\)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
+  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.name          = "edn"
-  gem.require_paths = ["lib"]
+  gem.name          = 'edn'
+  gem.require_paths = ['lib']
   gem.version       = EDN::VERSION
 
   gem.add_development_dependency 'pry', '~> 0.9.10'
-  gem.add_development_dependency 'rspec', '~> 2.11.0'
-  gem.add_development_dependency 'rantly', '~> 0.3.1'
   gem.add_development_dependency 'rake', '~> 10.3'
+  gem.add_development_dependency 'rantly', '~> 0.3.1'
+  gem.add_development_dependency 'rspec', '~> 2.11.0'
 end

--- a/lib/edn/char_stream.rb
+++ b/lib/edn/char_stream.rb
@@ -1,41 +1,45 @@
+# frozen_string_literal: true
+
 require 'stringio'
 require 'set'
 
 module EDN
   class CharStream
-    def initialize(io=$stdin)
+    def initialize(io = $stdin)
       @io = io
       @current = nil
     end
 
     def current
       return @current if @current
+
       advance
     end
 
     def advance
       return @current if @current == :eof
+
       @current = @io.getc || :eof
     end
 
-    def digit?(c=current)
+    def digit?(c = current)
       /[0-9]/.match?(c)
     end
 
-    def alpha?(c=current)
+    def alpha?(c = current)
       /[a-zA-Z]/.match?(c)
     end
 
-    def eof?(c=current)
+    def eof?(c = current)
       c == :eof
     end
 
-    def ws?(c=current)
-      /[ \t\r\n,]/ =~ c
+    def ws?(c = current)
+      /[ \t\r\n,]/.match?(c)
     end
 
-    def newline?(c=current)
-      /[\n\r]/ =~ c
+    def newline?(c = current)
+      /[\n\r]/.match?(c)
     end
 
     def repeat(pattern, &block)
@@ -53,7 +57,7 @@ module EDN
       end
     end
 
-    def skip_past(expected, error_message=nil)
+    def skip_past(expected, error_message = nil)
       if current == expected
         advance
         return expected
@@ -64,9 +68,7 @@ module EDN
     end
 
     def skip_to_eol
-      until current == :eof || newline?
-        advance
-      end
+      advance until current == :eof || newline?
     end
 
     def skip_ws

--- a/lib/edn/char_stream.rb
+++ b/lib/edn/char_stream.rb
@@ -19,11 +19,11 @@ module EDN
     end
 
     def digit?(c=current)
-      /[0-9]/ =~ c
+      /[0-9]/.match?(c)
     end
 
     def alpha?(c=current)
-      /[a-zA-Z]/ =~ c
+      /[a-zA-Z]/.match?(c)
     end
 
     def eof?(c=current)

--- a/lib/edn/core_ext.rb
+++ b/lib/edn/core_ext.rb
@@ -16,9 +16,9 @@ module EDN
       end
     end
 
-    module Bignum
+    module Integer
       def to_edn
-        self.to_s + 'M'
+        self.to_s
       end
     end
 
@@ -94,7 +94,7 @@ module EDN
 end
 
 Numeric.send(:include, EDN::CoreExt::Unquoted)
-Bignum.send(:include, EDN::CoreExt::Bignum)
+Integer.send(:include, EDN::CoreExt::Integer)
 BigDecimal.send(:include, EDN::CoreExt::BigDecimal)
 TrueClass.send(:include, EDN::CoreExt::Unquoted)
 FalseClass.send(:include, EDN::CoreExt::Unquoted)

--- a/spec/edn/char_stream_spec.rb
+++ b/spec/edn/char_stream_spec.rb
@@ -1,111 +1,116 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-describe EDN::CharStream do
-  it "reads a stream in order" do
-    s = EDN::CharStream.new(io_for("abc"))
-    s.current.should == "a"
-    s.advance.should == "b"
-    s.advance.should == "c"
-    s.advance.should == :eof
-    s.current.should == :eof
+RSpec.describe EDN::CharStream do
+  it 'reads a stream in order' do
+    s = EDN::CharStream.new(io_for('abc'))
+    expect(s.current).to eq('a')
+    expect(s.advance).to eq('b')
+    expect(s.advance).to eq('c')
+    expect(s.advance).to eq(:eof)
+    expect(s.current).to eq(:eof)
   end
 
-  it "keeps returning the current until your advance" do
-    s = EDN::CharStream.new(io_for("abc"))
-    s.current.should == "a"
-    s.current.should == "a"
-    s.advance.should == "b"
+  it 'keeps returning the current until your advance' do
+    s = EDN::CharStream.new(io_for('abc'))
+    expect(s.current).to eq('a')
+    expect(s.advance).to eq('b')
+    expect(s.advance).to eq('c')
   end
 
-  it "knows if the current char is a digit" do
-    s = EDN::CharStream.new(io_for("4f"))
-    s.digit?.should be_true
+  it 'knows if the current char is a digit' do
+    s = EDN::CharStream.new(io_for('4f'))
+    expect(s).to be_digit
     s.advance
-    s.digit?.should be_false
+    expect(s).not_to be_digit
   end
 
-  it "knows if the current char is an alpha" do
-    s = EDN::CharStream.new(io_for("a9"))
-    s.alpha?.should be_true
+  it 'knows if the current char is an alpha' do
+    s = EDN::CharStream.new(io_for('a9'))
+    expect(s).to be_alpha
     s.advance
-    s.alpha?.should be_false
+    expect(s).not_to be_alpha
   end
 
-  it "knows if the current char is whitespace" do
+  it 'knows if the current char is whitespace' do
     s = EDN::CharStream.new(io_for("a b\nc\td,"))
-    s.ws?.should be_false # a
+    expect(s).not_to be_ws
 
     s.advance
-    s.ws?.should be_true # " "
+    expect(s).to be_ws
 
     s.advance
-    s.ws?.should be_false # b
+    expect(s).not_to be_ws
 
     s.advance
-    s.ws?.should be_true # \n
+    expect(s).to be_ws
 
     s.advance
-    s.ws?.should be_false # c
+    expect(s).not_to be_ws
 
     s.advance
-    s.ws?.should be_true # \t
+    expect(s).to be_ws
 
     s.advance
-    s.ws?.should be_false # d
+    expect(s).not_to be_ws
 
     s.advance
-    s.ws?.should be_true # ,
+    expect(s).to be_ws
   end
 
-  it "knows if the current char is a newline" do
+  it 'knows if the current char is a newline' do
     s = EDN::CharStream.new(io_for("a\nb\rc"))
-    s.newline?.should be_false # a
+    expect(s).not_to be_newline
 
     s.advance
-    s.newline?.should be_true # \n
+    expect(s).to be_newline
 
     s.advance
-    s.newline?.should be_false # b
+    expect(s).not_to be_newline
 
     s.advance
-    s.newline?.should be_true # \r
+    expect(s).to be_newline
 
     s.advance
-    s.newline?.should be_false # c
+    expect(s).not_to be_newline
   end
 
-  it "knows if it is at the eof" do
-    s = EDN::CharStream.new(io_for("abc"))
-    s.eof?.should be_false # a
+  it 'knows if it is at the eof' do
+    s = EDN::CharStream.new(io_for('abc'))
+    expect(s).not_to be_eof
+
     s.advance
-    s.eof?.should be_false # b
+    expect(s).not_to be_eof
+
     s.advance
-    s.eof?.should be_false # c
+    expect(s).not_to be_eof
+
     s.advance
-    s.eof?.should be_true
+    expect(s).to be_eof
   end
 
-  it "knows how to skip past a char" do
-    s = EDN::CharStream.new(io_for("abc"))
-    s.skip_past("a").should == "a"
-    s.current.should == "b"
+  it 'knows how to skip past a char' do
+    s = EDN::CharStream.new(io_for('abc'))
+    expect(s.skip_past('a')).to eq('a')
+    expect(s.current).to eq('b')
   end
 
-  it "knows how not to skip a char" do
-    s = EDN::CharStream.new(io_for("abc"))
-    s.skip_past("X").should be_nil
+  it 'knows how not to skip a char' do
+    s = EDN::CharStream.new(io_for('abc'))
+    expect(s.skip_past('X')).to be_nil
   end
 
-  it "knows how skip to the end of a line" do
+  it 'knows how skip to the end of a line' do
     s = EDN::CharStream.new(io_for("abc\ndef"))
     s.skip_to_eol
-    s.current.should == "\n"
-    s.advance.should == "d"
+    expect(s.current).to eq("\n")
+    expect(s.advance).to eq('d')
   end
 
-  it "knows how skip whitespace" do
+  it 'knows how skip whitespace' do
     s = EDN::CharStream.new(io_for("  \n \t,,,,abc"))
     s.skip_ws
-    s.current.should == "a"
+    expect(s.current).to eq('a')
   end
 end

--- a/spec/edn/char_stream_spec.rb
+++ b/spec/edn/char_stream_spec.rb
@@ -19,70 +19,70 @@ describe EDN::CharStream do
 
   it "knows if the current char is a digit" do
     s = EDN::CharStream.new(io_for("4f"))
-    s.digit?.should be_truthy
+    s.digit?.should be_true
     s.advance
-    s.digit?.should be_falsey
+    s.digit?.should be_false
   end
 
   it "knows if the current char is an alpha" do
     s = EDN::CharStream.new(io_for("a9"))
-    s.alpha?.should be_truthy
+    s.alpha?.should be_true
     s.advance
-    s.alpha?.should be_falsey
+    s.alpha?.should be_false
   end
 
   it "knows if the current char is whitespace" do
     s = EDN::CharStream.new(io_for("a b\nc\td,"))
-    s.ws?.should be_falsey # a
+    s.ws?.should be_false # a
 
     s.advance
-    s.ws?.should be_truthy # " "
+    s.ws?.should be_true # " "
 
     s.advance
-    s.ws?.should be_falsey # b
+    s.ws?.should be_false # b
 
     s.advance
-    s.ws?.should be_truthy # \n
+    s.ws?.should be_true # \n
 
     s.advance
-    s.ws?.should be_falsey # c
+    s.ws?.should be_false # c
 
     s.advance
-    s.ws?.should be_truthy # \t
+    s.ws?.should be_true # \t
 
     s.advance
-    s.ws?.should be_falsey # d
+    s.ws?.should be_false # d
 
     s.advance
-    s.ws?.should be_truthy # ,
+    s.ws?.should be_true # ,
   end
 
   it "knows if the current char is a newline" do
     s = EDN::CharStream.new(io_for("a\nb\rc"))
-    s.newline?.should be_falsey # a
+    s.newline?.should be_false # a
 
     s.advance
-    s.newline?.should be_truthy # \n
+    s.newline?.should be_true # \n
 
     s.advance
-    s.newline?.should be_falsey # b
+    s.newline?.should be_false # b
 
     s.advance
-    s.newline?.should be_truthy # \r
+    s.newline?.should be_true # \r
 
     s.advance
-    s.newline?.should be_falsey # c
+    s.newline?.should be_false # c
   end
 
   it "knows if it is at the eof" do
     s = EDN::CharStream.new(io_for("abc"))
-    s.eof?.should be_falsey # a
+    s.eof?.should be_false # a
     s.advance
-    s.eof?.should be_falsey # b
+    s.eof?.should be_false # b
     s.advance
-    s.eof?.should be_falsey # c
+    s.eof?.should be_false # c
     s.advance
-    s.eof?.should be_truthy
+    s.eof?.should be_true
   end
 
   it "knows how to skip past a char" do

--- a/spec/edn/metadata_spec.rb
+++ b/spec/edn/metadata_spec.rb
@@ -1,36 +1,35 @@
 require 'spec_helper'
 
-describe EDN do
-  describe "metadata" do
+RSpec.describe EDN do
+  describe 'metadata' do
     it "reads metadata, which does not change the element's equality" do
-      EDN.read('[1 2 3]').should == EDN.read('^{:doc "My vec"} [1 2 3]')
+      expect(EDN.read('[1 2 3]')).to eq(EDN.read('^{:doc "My vec"} [1 2 3]'))
     end
 
-    it "reads metadata recursively from right to left" do
+    it 'reads metadata recursively from right to left' do
       element = EDN.read('^String ^:foo ^{:foo false :tag Boolean :bar 2} [1 2]')
-      element.should == [1, 2]
-      element.metadata.should == {:tag => ~"String", :foo => true, :bar => 2}
+      expect(element).to eq([1, 2])
+      expect(element.metadata).to eq(tag: ~'String', foo: true, bar: 2)
     end
 
-    it "writes metadata" do
+    it 'writes metadata' do
       element = EDN.read('^{:doc "My vec"} [1 2 3]')
-      element.to_edn.should == '^{:doc "My vec"} [1 2 3]'
+      expect(element.to_edn).to eq('^{:doc "My vec"} [1 2 3]')
     end
 
-    it "only writes metadata for elements that can have it" do
+    it 'only writes metadata for elements that can have it' do
       apply_metadata = lambda { |o|
         o.extend(EDN::Metadata)
-        o.metadata = {:foo => 1}
+        o.metadata = { foo: 1 }
         o
       }
 
-      apply_metadata[[1, 2]].to_edn.should == '^{:foo 1} [1 2]'
-      apply_metadata[~[1, 2]].to_edn.should == '^{:foo 1} (1 2)'
-      apply_metadata[{1 => 2}].to_edn.should == '^{:foo 1} {1 2}'
-      apply_metadata[Set.new([1, 2])].to_edn.should == '^{:foo 1} #{1 2}'
-      apply_metadata[~"bar"].to_edn.should == '^{:foo 1} bar'
-
-      apply_metadata["bar"].to_edn.should == '"bar"'
+      expect(apply_metadata[[1, 2]].to_edn).to eq('^{:foo 1} [1 2]')
+      expect(apply_metadata[~[1, 2]].to_edn).to eq('^{:foo 1} (1 2)')
+      expect(apply_metadata[{ 1 => 2 }].to_edn).to eq('^{:foo 1} {1 2}')
+      expect(apply_metadata[Set.new([1, 2])].to_edn).to eq('^{:foo 1} #{1 2}')
+      expect(apply_metadata[~'bar'].to_edn).to eq('^{:foo 1} bar')
+      expect(apply_metadata['bar'].to_edn).to eq('"bar"')
 
       # Cannot extend symbols, booleans, and nil, so no test for them.
     end

--- a/spec/edn/parser_spec.rb
+++ b/spec/edn/parser_spec.rb
@@ -1,159 +1,161 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-describe 'edn_parser' do
+RSpec.describe 'edn_parser' do
   include RantlyHelpers
 
   let(:parser) { EDN.new_parser }
 
-  it "can contain comments" do
+  it 'can contain comments' do
     edn = ";; This is some sample data\n[1 2 ;; the first two values\n3]"
-    EDN.read(edn).should == [1, 2, 3]
+    expect(EDN.read(edn)).to eq([1, 2, 3])
   end
 
-  it "can discard using the discard reader macro" do
-    edn = "[1 2 #_3 {:foo #_bar :baz}]"
-    EDN.read(edn).should == [1, 2, {:foo => :baz}]
+  it 'can discard using the discard reader macro' do
+    edn = '[1 2 #_3 {:foo #_bar :baz}]'
+    expect(EDN.read(edn)).to eq([1, 2, { foo: :baz }])
   end
 
-  context "element" do
-    it "should consume metadata with the element" do
+  context 'element' do
+    it 'should consume metadata with the element' do
       x = EDN.read('^{:doc "test"} [1 2]')
-      x.should == [1, 2]
-      x.metadata.should == {doc: "test"}
+      expect(x).to eq([1, 2])
+      expect(x.metadata).to eq(doc: 'test')
     end
   end
 
-  context "integer" do
-    it "should consume integers" do
+  context 'integer' do
+    it 'should consume integers' do
       rant(RantlyHelpers::INTEGER).each do |int|
-        (EDN.read int.to_s).should == int.to_i
+        expect(EDN.read(int.to_s)).to eq(int.to_i)
       end
     end
 
-    it "should consume integers prefixed with a +" do
+    it 'should consume integers prefixed with a +' do
       rant(RantlyHelpers::INTEGER).each do |int|
-        (EDN.read "+#{int.to_i.abs.to_s}").should == int.to_i.abs
+        expect(EDN.read("+#{int.to_i.abs}")).to eq(int.to_i.abs)
       end
     end
   end
 
-  context "float" do
-    it "should consume simple floats" do
+  context 'float' do
+    it 'should consume simple floats' do
       rant(RantlyHelpers::FLOAT).each do |float|
-        EDN.read(float.to_s).should == float.to_f
+        expect(EDN.read(float.to_s)).to eq(float.to_f)
       end
     end
 
-    it "should consume floats with exponents" do
+    it 'should consume floats with exponents' do
       rant(RantlyHelpers::FLOAT_WITH_EXP).each do |float|
-        EDN.read(float.to_s).should == float.to_f
+        expect(EDN.read(float.to_s)).to eq(float.to_f)
       end
     end
 
-    it "should consume floats prefixed with a +" do
+    it 'should consume floats prefixed with a +' do
       rant(RantlyHelpers::FLOAT).each do |float|
-        EDN.read("+#{float.to_f.abs.to_s}").should == float.to_f.abs
+        expect(EDN.read("+#{float.to_f.abs}")).to eq(float.to_f.abs)
       end
     end
   end
 
-  context "symbol" do
-    context "special cases" do
+  context 'symbol' do
+    context 'special cases' do
       it "should consume '/'" do
-        EDN.read('/').should == EDN::Type::Symbol.new(:"/")
+        expect(EDN.read('/')).to eq(EDN::Type::Symbol.new(:"/"))
       end
 
       it "should consume '.'" do
-        EDN.read('.').should == EDN::Type::Symbol.new(:".")
+        expect(EDN.read('.')).to eq(EDN::Type::Symbol.new(:"."))
       end
 
       it "should consume '-'" do
-        EDN.read('-').should == EDN::Type::Symbol.new(:"-")
+        expect(EDN.read('-')).to eq(EDN::Type::Symbol.new(:"-"))
       end
     end
   end
 
-  context "keyword" do
-    it "should consume any keywords" do
+  context 'keyword' do
+    it 'should consume any keywords' do
       rant(RantlyHelpers::SYMBOL).each do |symbol|
-        EDN.read(":#{symbol}").should == symbol.to_sym
+        expect(EDN.read(":#{symbol}")).to eq(symbol.to_sym)
       end
     end
   end
 
-  context "string" do
-    it "should consume any string" do
+  context 'string' do
+    it 'should consume any string' do
       rant(RantlyHelpers::RUBY_STRING).each do |string|
-        EDN.read(string.to_edn).should == string
+        expect(EDN.read(string.to_edn)).to eq(string)
       end
     end
   end
 
-  context "character" do
-    it "should consume any character" do
+  context 'character' do
+    it 'should consume any character' do
       rant(RantlyHelpers::RUBY_CHAR).each do |char|
-        EDN.read(char.to_edn).should == char
+        expect(EDN.read(char.to_edn)).to eq(char)
       end
     end
   end
 
-  context "vector" do
-    it "should consume an empty vector" do
-      EDN.read('[]').should == []
-      EDN.read('[  ]').should == []
+  context 'vector' do
+    it 'should consume an empty vector' do
+      expect(EDN.read('[]')).to eq([])
+      expect(EDN.read('[  ]')).to eq([])
     end
 
-    it "should consume vectors of mixed elements" do
+    it 'should consume vectors of mixed elements' do
       rant(RantlyHelpers::VECTOR).each do |vector|
         expect { EDN.read(vector) }.to_not raise_error
       end
     end
   end
 
-  context "list" do
-    it "should consume an empty list" do
-      EDN.read('()').should == []
-      EDN.read('( )').should == []
+  context 'list' do
+    it 'should consume an empty list' do
+      expect(EDN.read('()')).to eq([])
+      expect(EDN.read('( )')).to eq([])
     end
 
-    it "should consume lists of mixed elements" do
+    it 'should consume lists of mixed elements' do
       rant(RantlyHelpers::LIST).each do |list|
         expect { EDN.read(list) }.to_not raise_error
       end
     end
   end
 
-  context "set" do
-    it "should consume an empty set" do
-      EDN.read('#{}').should == Set.new
-      EDN.read('#{ }').should == Set.new
+  context 'set' do
+    it 'should consume an empty set' do
+      expect(EDN.read('#{}')).to eq(Set.new)
+      expect(EDN.read('#{ }')).to eq(Set.new)
     end
 
-    it "should consume sets of mixed elements" do
+    it 'should consume sets of mixed elements' do
       rant(RantlyHelpers::SET).each do |set|
         EDN.read(set)
       end
     end
   end
 
-  context "map" do
-    it "should consume maps of mixed elements" do
+  context 'map' do
+    it 'should consume maps of mixed elements' do
       rant(RantlyHelpers::MAP).each do |map|
         expect { EDN.read(map) }.not_to raise_error
       end
     end
   end
 
-  context "tagged element" do
-    context "#inst" do
-      it "should consume #inst" do
+  context 'tagged element' do
+    context '#inst' do
+      it 'should consume #inst' do
         rant(RantlyHelpers::INST).each do |element|
           expect { EDN.read(element) }.not_to raise_error
         end
       end
     end
 
-    it "should consume tagged elements" do
+    it 'should consume tagged elements' do
       rant(RantlyHelpers::TAGGED_ELEMENT).each do |element|
         expect { EDN.read(element) }.not_to raise_error
       end

--- a/spec/edn/reader_spec.rb
+++ b/spec/edn/reader_spec.rb
@@ -1,23 +1,25 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-describe EDN::Reader do
-  let(:reader) { EDN::Reader.new("[1 2] 3 :a {:b c} ") }
+RSpec.describe EDN::Reader do
+  let(:reader) { EDN::Reader.new('[1 2] 3 :a {:b c} ') }
 
-  it "should read each value" do
-    reader.read.should == [1, 2]
-    reader.read.should == 3
-    reader.read.should == :a
-    reader.read.should == {:b => ~"c"}
+  it 'should read each value' do
+    expect(reader.read).to eq([1, 2])
+    expect(reader.read).to eq(3)
+    expect(reader.read).to eq(:a)
+    expect(reader.read).to eq(b: ~'c')
   end
 
-  it "should respond to each" do
+  it 'should respond to each' do
     reader.each do |element|
-      element.should_not be_nil
+      expect(element).not_to be_nil
     end
   end
 
-  it "returns a special end of file value if asked" do
-    4.times { reader.read(:the_end).should_not == :the_end }
-    reader.read(:no_more).should == :no_more
+  it 'returns a special end of file value if asked' do
+    4.times { expect(reader.read(:the_end)).not_to eq(:the_end) }
+    expect(reader.read(:no_more)).to eq(:no_more)
   end
 end

--- a/spec/edn_spec.rb
+++ b/spec/edn_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'stringio'
 
@@ -16,7 +18,7 @@ describe EDN do
         actual.should == expected
       end
 
-       it "round trips the value in #{File.basename(edn_file)} correctly" do
+      it "round trips the value in #{File.basename(edn_file)} correctly" do
         expected = eval(File.read(rb_file))
         actual = EDN.read(File.read(edn_file))
         round_trip = EDN.read(actual.to_edn)
@@ -25,82 +27,81 @@ describe EDN do
     end
   end
 
-
-  context "#read" do
-    #it "reads from a stream" do
+  context '#read' do
+    # it "reads from a stream" do
     #  io = StringIO.new("123")
     #  EDN.read(io).should == 123
-    #end
+    # end
 
-    #it "reads mutiple values from a stream" do
+    # it "reads mutiple values from a stream" do
     #  io = StringIO.new("123 456 789")
     #  EDN.read(io).should == 123
     #  EDN.read(io).should == 456
     #  EDN.read(io).should == 789
-    #end
+    # end
 
-    it "raises an exception on eof by default" do
+    it 'raises an exception on eof by default' do
       expect { EDN.read('') }.to raise_error
     end
 
-    #it "allows you to specify an eof value" do
+    # it "allows you to specify an eof value" do
     #  io = StringIO.new("123 456")
     #  EDN.read(io, :my_eof).should == 123
     #  EDN.read(io, :my_eof).should == 456
     #  EDN.read(io, :my_eof).should == :my_eof
-    #end
+    # end
 
-    it "allows you to specify nil as an eof value" do
-      EDN.read("", nil).should == nil
+    it 'allows you to specify nil as an eof value' do
+      EDN.read('', nil).should.nil?
     end
   end
 
-  context "reading data" do
-    it "treats carriage returns like whitespace" do
+  context 'reading data' do
+    it 'treats carriage returns like whitespace' do
       EDN.read("\r\n[\r\n]\r\n").should == []
       EDN.read("\r[\r]\r\r").should == []
     end
 
-    it "reads any valid element" do
+    it 'reads any valid element' do
       elements = rant(RantlyHelpers::ELEMENT)
       elements.each do |element|
         begin
-          if element == "nil"
+          if element == 'nil'
             EDN.read(element).should be_nil
           else
             EDN.read(element).should_not be_nil
           end
-        rescue Exception => ex
+        rescue Exception => e
           puts "Bad element: #{element}"
-          raise ex
+          raise e
         end
       end
     end
   end
 
-  context "#register" do
-    it "uses the identity function when no handler is given" do
-      EDN.register "some/tag"
-      EDN.read("#some/tag {}").class.should == Hash
+  context '#register' do
+    it 'uses the identity function when no handler is given' do
+      EDN.register 'some/tag'
+      EDN.read('#some/tag {}').class.should == Hash
     end
   end
 
-  context "writing" do
-    it "writes any valid element" do
+  context 'writing' do
+    it 'writes any valid element' do
       elements = rant(RantlyHelpers::ELEMENT)
       elements.each do |element|
-        expect {
+        expect do
           begin
             EDN.read(element).to_edn
-          rescue Exception => ex
+          rescue Exception => e
             puts "Bad element: #{element}"
-            raise ex
+            raise e
           end
-        }.to_not raise_error
+        end.to_not raise_error
       end
     end
 
-    it "writes equivalent edn to what it reads" do
+    it 'writes equivalent edn to what it reads' do
       elements = rant(RantlyHelpers::ELEMENT)
       elements.each do |element|
         ruby_element = EDN.read(element)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,16 +1,17 @@
+# frozen_string_literal: true
+
 require 'rspec'
 require 'edn'
 require 'rantly'
 require 'date'
 require 'time'
 
-REPEAT = (ENV["REPEAT"] || 150).to_i
+REPEAT = (ENV['REPEAT'] || 150).to_i
 
 RSpec.configure do |c|
   c.fail_fast = true
-  c.filter_run_including :focused => true
-  c.alias_example_to :fit, :focused => true
-  c.treat_symbols_as_metadata_keys_with_true_values = true
+  c.filter_run_including focused: true
+  c.alias_example_to :fit, focused: true
   c.run_all_when_everything_filtered = true
 
   c.filter_run :focus
@@ -22,7 +23,6 @@ def io_for(s)
 end
 
 module RantlyHelpers
-
   KEYWORD = lambda { |_|
     call(SYMBOL).to_sym.to_edn
   }
@@ -32,55 +32,55 @@ module RantlyHelpers
   }
 
   PLAIN_SYMBOL = lambda { |_|
-    sized(range(1, 100)) {
+    sized(range(1, 100)) do
       s = string(/[[:alnum:]]|[\.\*\+\!\-\?\$_%<>&=:#]/)
       guard s !~ /^[0-9]/
       guard s !~ /^[\+\-\.][0-9]/
       guard s !~ /^[\:\#]/
       s
-    }
+    end
   }
 
   NAMESPACED_SYMBOL = lambda { |_|
-    [call(PLAIN_SYMBOL), call(PLAIN_SYMBOL)].join("/")
+    [call(PLAIN_SYMBOL), call(PLAIN_SYMBOL)].join('/')
   }
 
-  INTEGER = lambda { |_| integer.to_edn }
+  INTEGER = ->(_) { integer.to_edn }
 
-  STRING = lambda { |_| sized(range(1, 100)) { string.to_edn } }
+  STRING = ->(_) { sized(range(1, 100)) { string.to_edn } }
 
-  RUBY_STRING = lambda { |_| sized(range(1, 100)) { string } }
+  RUBY_STRING = ->(_) { sized(range(1, 100)) { string } }
 
-  FLOAT = lambda { |_| (float * range(-4000, 5000)).to_edn }
+  FLOAT = ->(_) { (float * range(-4000, 5000)).to_edn }
 
   FLOAT_WITH_EXP = lambda { |_|
     # limited range because of Infinity
     f = float.to_s
     guard f !~ /[Ee]/
 
-    [f, choose("e", "E", "e+", "E+", "e-", "e+"), range(1, 100)].
-    map(&:to_s).
-    join("")
+    [f, choose('e', 'E', 'e+', 'E+', 'e-', 'e+'), range(1, 100)]
+      .map(&:to_s)
+      .join('')
   }
 
   RUBY_CHAR = lambda { |_|
-    "\\" +
-    sized(1) {
-      freq([1, [:choose, "\n", "\r", " ", "\t"]],
-           [5, [:string, :graph]])
-    }
+    '\\' +
+      sized(1) do
+        freq([1, [:choose, "\n", "\r", ' ', "\t"]],
+             [5, %i[string graph]])
+      end
   }
 
   CHARACTER = lambda { |_|
-    "\\" +
-    sized(1) {
-      freq([1, [:choose, "newline", "return", "space", "tab"]],
-           [5, [:string, :graph]])
-    }
+    '\\' +
+      sized(1) do
+        freq([1, [:choose, 'newline', 'return', 'space', 'tab']],
+             [5, %i[string graph]])
+      end
   }
 
   BOOL_OR_NIL = lambda { |_|
-    choose("true", "false", "nil")
+    choose('true', 'false', 'nil')
   }
 
   ARRAY = lambda { |_|
@@ -104,7 +104,7 @@ module RantlyHelpers
     keys = array(size) { call(ELEMENT) }
     elements = array(size) { call(ELEMENT) }
     arrays = keys.zip(elements)
-    '{' + arrays.map { |array| array.join(" ") }.join(", ") + '}'
+    '{' + arrays.map { |array| array.join(' ') }.join(', ') + '}'
   }
 
   ELEMENT = lambda { |_|
@@ -134,11 +134,11 @@ module RantlyHelpers
     keys = array(size) { branch(KEYWORD, SYMBOL, STRING) }
     elements = array(size) { call(ELEMENT) }
     arrays = keys.zip(elements)
-    '^{' + arrays.map { |array| array.join(" ") }.join(", ") + '}'
+    '^{' + arrays.map { |array| array.join(' ') }.join(', ') + '}'
   }
 
   ELEMENT_WITH_METADATA = lambda { |_|
-    [call(METADATA), branch(SYMBOL, VECTOR, LIST, SET, MAP)].join(" ")
+    [call(METADATA), branch(SYMBOL, VECTOR, LIST, SET, MAP)].join(' ')
   }
 
   TAG = lambda { |_|
@@ -148,12 +148,12 @@ module RantlyHelpers
   }
 
   TAGGED_ELEMENT = lambda { |_|
-    [call(TAG), call(BASIC_ELEMENT)].join(" ")
+    [call(TAG), call(BASIC_ELEMENT)].join(' ')
   }
 
   INST = lambda { |_|
     begin
-      DateTime.new(range(0, 2500), range(1, 12), range(1, 28), range(0, 23), range(0, 59), range(0, 59), "#{range(-12,12)}").to_edn
+      DateTime.new(range(0, 2500), range(1, 12), range(1, 28), range(0, 23), range(0, 59), range(0, 59), range(-12, 12).to_s).to_edn
     rescue ArgumentError
       guard false
     end


### PR DESCRIPTION
This PR does the following:

- Upgrades RSpec and fixes all the spec files to use valid syntax.
- Fixes `Integer#to_edn` so it does not append `M` after values
- Configures CircleCI integration
- Fixes some  deprecation warns