### PR TITLE
BigDecimal.new() -> BigDecimal() for Ruby 2.7 (BigDecimal 2)

### DIFF
--- a/lib/edn.rb
+++ b/lib/edn.rb
@@ -61,6 +61,10 @@ module EDN
     Set.new(*elems)
   end
 
+  def self.rational(value)
+    Rational(value)
+  end
+  
   def self.big_decimal(str)
     BigDecimal(str)
   end

--- a/lib/edn.rb
+++ b/lib/edn.rb
@@ -62,7 +62,7 @@ module EDN
   end
 
   def self.big_decimal(str)
-    BigDecimal.new(str)
+    BigDecimal(str)
   end
 end
 

--- a/lib/edn/core_ext.rb
+++ b/lib/edn/core_ext.rb
@@ -15,14 +15,8 @@ module EDN
         true
       end
     end
-    
-    module Integer
-      def to_edn
-        self.to_s + 'N'
-      end
-    end
 
-    module Bignum
+    module Integer
       def to_edn
         self.to_s + 'N'
       end
@@ -101,7 +95,6 @@ end
 
 Numeric.send(:include, EDN::CoreExt::Unquoted)
 Integer.send(:include, EDN::CoreExt::Integer)
-Bignum.send(:include, EDN::CoreExt::Bignum)
 BigDecimal.send(:include, EDN::CoreExt::BigDecimal)
 TrueClass.send(:include, EDN::CoreExt::Unquoted)
 FalseClass.send(:include, EDN::CoreExt::Unquoted)

--- a/lib/edn/core_ext.rb
+++ b/lib/edn/core_ext.rb
@@ -24,7 +24,7 @@ module EDN
 
     module Bignum
       def to_edn
-        self.to_s + 'M'
+        self.to_s + 'N'
       end
     end
 

--- a/lib/edn/core_ext.rb
+++ b/lib/edn/core_ext.rb
@@ -15,6 +15,12 @@ module EDN
         true
       end
     end
+    
+    module Integer
+      def to_edn
+        self.to_s + 'N'
+      end
+    end
 
     module Bignum
       def to_edn

--- a/lib/edn/core_ext.rb
+++ b/lib/edn/core_ext.rb
@@ -100,6 +100,7 @@ module EDN
 end
 
 Numeric.send(:include, EDN::CoreExt::Unquoted)
+Integer.send(:include, EDN::CoreExt::Integer)
 Bignum.send(:include, EDN::CoreExt::Bignum)
 BigDecimal.send(:include, EDN::CoreExt::BigDecimal)
 TrueClass.send(:include, EDN::CoreExt::Unquoted)

--- a/lib/edn/version.rb
+++ b/lib/edn/version.rb
@@ -1,3 +1,3 @@
 module EDN
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end


### PR DESCRIPTION
BigDecimal 2 (included with Ruby 2.7 by default) removed the `BigDecimal.new` constructor in favor of the more consistent `BigDecimal(value)` constructor to make it consistent with other number types in ruby.

Both constructors are the same, so the new one will work on older ruby versions (and bigdecimal versions).